### PR TITLE
feat: 貼り付け移動の確定/キャンセル操作を追加（Enter/Esc）

### DIFF
--- a/DEVELOP.ja.md
+++ b/DEVELOP.ja.md
@@ -35,6 +35,7 @@ npm run dist
   - 削除
   - 貼り付け
   - 貼り付け直後のドラッグ移動（Selectツール）
+  - 浮動貼り付け/移動の操作: `Enter` で確定、`Esc` でキャンセルして貼り付け前状態に復元
   - 矩形選択したピクセルのドラッグ移動（貼り付け移動と同じ挙動）
 - Undo
 - PNG保存/読込
@@ -64,6 +65,8 @@ npm run dist
   - `Cmd/Ctrl + Z`: Undo
   - `Cmd/Ctrl + C`: 選択範囲コピー
   - `Cmd/Ctrl + V`: 貼り付け
+  - `Enter`: 浮動貼り付け/移動を確定
+  - `Esc`: 浮動貼り付け/移動をキャンセルして元に戻す
 
 ## 6. PNGメタ情報仕様
 PNGの `tEXt` チャンクに、キーワード `pixel-editor-meta` で保存。
@@ -109,8 +112,6 @@ PNGの `tEXt` チャンクに、キーワード `pixel-editor-meta` で保存。
 - 塗りつぶしは4近傍の連結同色領域に対して実行。
 
 ## 9. 既知の改善候補
-- 貼り付け移動の確定/キャンセルUX改善
-  - 例: `Enter` 確定、`Esc` キャンセル
 - クリップボード連携はハイブリッド
   - 内部ピクセルクリップボード + OS画像クリップボード
 
@@ -125,3 +126,12 @@ PNGの `tEXt` チャンクに、キーワード `pixel-editor-meta` で保存。
 - ルートに `+` という未使用ファイルが存在（`/Users/abatan/Develop/PixelEditor/+`）
   - 実行には不要
   - 削除する場合はユーザー確認を取ること
+
+## 12. GitHubバックログ（2026-02-16作成）
+- ラベル運用ルール:
+  - このリポジトリのIssueラベルは日本語で統一する
+  - 推奨例: `機能追加`, `仕様変更`, `高`, `中`, `低`
+- #2 `feat: 貼り付け移動の確定/キャンセル操作を追加（Enter/Esc）`
+  - https://github.com/abatanx/DlaPixy/issues/2
+- #3 `refactor: クリップボード連携を整理（内部ピクセルとOSクリップボードの責務分離）`
+  - https://github.com/abatanx/DlaPixy/issues/3

--- a/DEVELOP.md
+++ b/DEVELOP.md
@@ -35,6 +35,7 @@ npm run dist
   - Delete selection
   - Paste selection
   - After paste: pasted block is draggable immediately (with Select tool)
+  - Floating paste/move controls: `Enter` to finalize, `Esc` to cancel and restore pre-paste state
   - Selected pixels are draggable directly (same behavior as pasted floating block)
 - Undo
 - Save/Load PNG
@@ -63,6 +64,8 @@ npm run dist
   - `Cmd/Ctrl + Z`: Undo
   - `Cmd/Ctrl + C`: Copy selection
   - `Cmd/Ctrl + V`: Paste selection
+  - `Enter`: Finalize floating paste/move
+  - `Esc`: Cancel floating paste/move and restore previous state
 
 ## 6. PNG Metadata Contract
 Stored in PNG `tEXt` chunk keyword: `pixel-editor-meta`.
@@ -105,8 +108,6 @@ Current metadata shape:
 - Fill tool uses flood-fill over contiguous same-color pixels (4-neighbor).
 
 ## 9. Known UX/Tech Debt (Next Candidates)
-- Paste finalize/cancel UX can be improved:
-  - e.g. `Enter` to finalize, `Esc` to cancel.
 - Clipboard integration is hybrid:
   - Internal pixel clipboard for precise paste behavior
   - OS image clipboard write is also performed
@@ -121,3 +122,12 @@ Current metadata shape:
 - There is a stray root file named `+` in workspace (`/Users/abatan/Develop/PixelEditor/+`).
   - It is not used by app runtime.
   - Remove only if user confirms.
+
+## 12. GitHub Backlog (Created 2026-02-16)
+- Label policy:
+  - Use Japanese labels for GitHub issues in this repository.
+  - Preferred examples: `機能追加`, `仕様変更`, `高`, `中`, `低`.
+- #2 `feat: Paste finalize/cancel operations (Enter/Esc)`
+  - https://github.com/abatanx/DlaPixy/issues/2
+- #3 `refactor: Clipboard integration responsibility split`
+  - https://github.com/abatanx/DlaPixy/issues/3


### PR DESCRIPTION
## 概要
- 貼り付け移動の浮動状態に対して、`Enter` で確定、`Esc` でキャンセル（貼り付け前状態へ復元）を追加
- 既存ショートカット（`Cmd/Ctrl+Z`, `Cmd/Ctrl+C`, `Cmd/Ctrl+V`）と競合しないようにショートカット処理を整理
- キャンバスリサイズ/ロード/Undo など既存の状態クリアフローとの整合を維持

## 確認観点
- 貼り付け直後に `Enter` で浮動状態が解除される
- 貼り付け直後に `Esc` で貼り付け前状態に戻る
- 既存操作（コピー/貼り付け/Undo）に退行がない

Closes #2